### PR TITLE
ima: Access decompressed kernel module to verify appended signature

### DIFF
--- a/fs/kernel_read_file.c
+++ b/fs/kernel_read_file.c
@@ -107,7 +107,12 @@ ssize_t kernel_read_file(struct file *file, loff_t offset, void **buf,
 			goto out_free;
 		}
 
-		ret = security_kernel_post_read_file(file, *buf, i_size, id);
+		/*
+		 * security_kernel_post_read_file will be called later after
+		 * a read kernel module is truly decompressed
+		 */
+		if (id != READING_MODULE)
+			ret = security_kernel_post_read_file(file, *buf, i_size, id);
 	}
 
 out_free:

--- a/kernel/module/main.c
+++ b/kernel/module/main.c
@@ -3678,6 +3678,7 @@ static int init_module_from_file(struct file *f, const char __user * uargs, int 
 	struct load_info info = { };
 	void *buf = NULL;
 	int len;
+	int err;
 
 	len = kernel_read_file(f, 0, &buf, INT_MAX, NULL, READING_MODULE);
 	if (len < 0) {
@@ -3686,7 +3687,7 @@ static int init_module_from_file(struct file *f, const char __user * uargs, int 
 	}
 
 	if (flags & MODULE_INIT_COMPRESSED_FILE) {
-		int err = module_decompress(&info, buf, len);
+		err = module_decompress(&info, buf, len);
 		vfree(buf); /* compressed data is no longer needed */
 		if (err) {
 			mod_stat_inc(&failed_decompress);
@@ -3696,6 +3697,14 @@ static int init_module_from_file(struct file *f, const char __user * uargs, int 
 	} else {
 		info.hdr = buf;
 		info.len = len;
+	}
+
+	err = security_kernel_post_read_file(f, (char *)info.hdr, info.len,
+					     READING_MODULE);
+	if (err) {
+		mod_stat_inc(&failed_kreads);
+		free_copy(&info, flags);
+		return err;
 	}
 
 	return load_module(&info, uargs, flags);

--- a/security/integrity/ima/ima_policy.c
+++ b/security/integrity/ima/ima_policy.c
@@ -241,7 +241,7 @@ static struct ima_rule_entry build_appraise_rules[] __ro_after_init = {
 
 static struct ima_rule_entry secure_boot_rules[] __ro_after_init = {
 	{.action = APPRAISE, .func = MODULE_CHECK,
-	 .flags = IMA_FUNC | IMA_DIGSIG_REQUIRED},
+	 .flags = IMA_FUNC | IMA_DIGSIG_REQUIRED | IMA_MODSIG_ALLOWED | IMA_CHECK_BLACKLIST},
 	{.action = APPRAISE, .func = FIRMWARE_CHECK,
 	 .flags = IMA_FUNC | IMA_DIGSIG_REQUIRED},
 	{.action = APPRAISE, .func = KEXEC_KERNEL_CHECK,


### PR DESCRIPTION
Currently, when in-kernel module decompression (CONFIG_MODULE_DECOMPRESS) is
enabled, IMA has no way to verify the appended module signature as it can't
decompress the module.

Defer calling security_kernel_module_read_file until a kernel module has been
decompressed. In this way, IMA can access both xattr and appended kernel module
signature. Note IMA is the only user of security_kernel_post_read_file so this
change won't affect other LSMs.

Before enabling in-kernel module decompression, a kernel module in initramfs
can still be loaded with ima_policy=secure_boot. So adjust the kernel module
rule in secure_boot policy to allow either an IMA signature OR an appended
signature i.e. to use "appraise func=MODULE_CHECK appraise_type=imasig|modsig".
