### PR TITLE
Support kdump with LUKS encryption by reusing LUKS volume keys for aarch64, ppc64le and s390x

### DIFF
--- a/arch/arm64/kernel/machine_kexec_file.c
+++ b/arch/arm64/kernel/machine_kexec_file.c
@@ -134,6 +134,15 @@ int load_other_segments(struct kimage *image,
 
 		kexec_dprintk("Loaded elf core header at 0x%lx bufsz=0x%lx memsz=0x%lx\n",
 			      image->elf_load_addr, kbuf.bufsz, kbuf.memsz);
+
+		ret = crash_load_dm_crypt_keys(image);
+
+		if (ret == -ENOENT) {
+			kexec_dprintk("No dm crypt key to load\n");
+		} else if (ret) {
+			pr_err("Failed to load dm crypt keys\n");
+			goto out_err;
+		}
 	}
 #endif
 

--- a/arch/powerpc/include/asm/kexec.h
+++ b/arch/powerpc/include/asm/kexec.h
@@ -99,6 +99,12 @@ int arch_check_excluded_range(struct kimage *image, unsigned long start,
 			      unsigned long end);
 #define arch_check_excluded_range  arch_check_excluded_range
 
+void arch_kexec_protect_crashkres(void);
+#define arch_kexec_protect_crashkres arch_kexec_protect_crashkres
+
+void arch_kexec_unprotect_crashkres(void);
+#define arch_kexec_unprotect_crashkres arch_kexec_unprotect_crashkres
+
 
 int load_crashdump_segments_ppc64(struct kimage *image,
 				  struct kexec_buf *kbuf);

--- a/arch/powerpc/include/asm/kexec.h
+++ b/arch/powerpc/include/asm/kexec.h
@@ -80,7 +80,8 @@ struct kimage_arch {
 };
 
 char *setup_kdump_cmdline(struct kimage *image, char *cmdline,
-			  unsigned long cmdline_len);
+			  unsigned long cmdline_len,
+			  char *name, unsigned long addr);
 int setup_purgatory(struct kimage *image, const void *slave_code,
 		    const void *fdt, unsigned long kernel_load_addr,
 		    unsigned long fdt_load_addr);

--- a/arch/powerpc/kexec/file_load.c
+++ b/arch/powerpc/kexec/file_load.c
@@ -34,25 +34,25 @@
  * Returns new cmdline buffer for kdump kernel on success, NULL otherwise.
  */
 char *setup_kdump_cmdline(struct kimage *image, char *cmdline,
-			  unsigned long cmdline_len)
+			  unsigned long cmdline_len,
+			  char *name, unsigned long addr)
 {
-	int elfcorehdr_strlen;
+	int new_cmd_strlen;
 	char *cmdline_ptr;
 
 	cmdline_ptr = kzalloc(COMMAND_LINE_SIZE, GFP_KERNEL);
 	if (!cmdline_ptr)
 		return NULL;
 
-	elfcorehdr_strlen = sprintf(cmdline_ptr, "elfcorehdr=0x%lx ",
-				    image->elf_load_addr);
+	new_cmd_strlen = sprintf(cmdline_ptr, "%s=0x%lx ", name, addr);
 
-	if (elfcorehdr_strlen + cmdline_len > COMMAND_LINE_SIZE) {
-		pr_err("Appending elfcorehdr=<addr> exceeds cmdline size\n");
+	if (new_cmd_strlen + cmdline_len > COMMAND_LINE_SIZE) {
+		pr_err("Appending %s=<addr> exceeds cmdline size\n", name);
 		kfree(cmdline_ptr);
 		return NULL;
 	}
 
-	memcpy(cmdline_ptr + elfcorehdr_strlen, cmdline, cmdline_len);
+	memcpy(cmdline_ptr + new_cmd_strlen, cmdline, cmdline_len);
 	// Ensure it's nul terminated
 	cmdline_ptr[COMMAND_LINE_SIZE - 1] = '\0';
 	return cmdline_ptr;

--- a/arch/s390/kernel/crash_dump.c
+++ b/arch/s390/kernel/crash_dump.c
@@ -705,3 +705,12 @@ ssize_t elfcorehdr_read_notes(char *buf, size_t count, u64 *ppos)
 	*ppos += count;
 	return count;
 }
+
+ssize_t dm_crypt_keys_read(char *buf, size_t count, u64 *ppos)
+{
+	void *src = __va((phys_addr_t)dm_crypt_keys_addr);
+
+	memcpy(buf, src, count);
+	*ppos += count;
+	return count;
+}

--- a/arch/s390/kernel/machine_kexec_file.c
+++ b/arch/s390/kernel/machine_kexec_file.c
@@ -239,6 +239,66 @@ out:
 	return ret;
 }
 
+#ifdef CONFIG_CRASH_DUMP
+static int setup_crash_dmcrypt(struct kimage *image, struct s390_load_data *data,
+			       unsigned long max_command_line_size)
+{
+	struct kexec_buf kexec_buf = { .random = true };
+	unsigned long temp_start, temp_end;
+	size_t cmd_buf_len;
+	char *cmd_buf;
+	int ret;
+
+	ret = crash_load_dm_crypt_keys(image);
+	if (ret == -ENOENT) {
+		kexec_dprintk("No dm crypt key to load\n");
+		return 0;
+	} else if (ret) {
+		pr_err("Failed to load dm crypt keys\n");
+		return -EINVAL;
+	}
+
+	kexec_buf.image = image;
+	kexec_buf.buffer = (void *)image->dm_crypt_keys_addr;
+	kexec_buf.bufsz = image->dm_crypt_keys_sz;
+	kexec_buf.memsz = kexec_buf.bufsz;
+
+	temp_start = data->memsz;
+	temp_end = temp_start + SZ_4M;
+	kexec_random_range_start(temp_start, temp_end, &kexec_buf,  &temp_start);
+	data->memsz = ALIGN(temp_start, PAGE_SIZE);
+	kexec_buf.mem = data->memsz;
+	kexec_buf.mem += crashk_res.start;
+
+	ret = kexec_add_buffer(&kexec_buf);
+	if (ret)
+		return ret;
+
+	data->memsz += kexec_buf.memsz;
+	ret = ipl_report_add_component(data->report, &kexec_buf, 0, 0);
+	if (ret)
+		return ret;
+
+	image->dm_crypt_keys_addr = kexec_buf.mem;
+	cmd_buf = kasprintf(GFP_KERNEL,
+			    "%s dmcryptkeys=0x%llx dmcryptkeys_size=%lu",
+			    image->cmdline_buf,
+			    kexec_buf.mem - crashk_res.start,
+			    image->dm_crypt_keys_sz);
+	cmd_buf_len = strlen(cmd_buf) + 1;
+
+	if (cmd_buf_len > max_command_line_size) {
+		kfree(cmd_buf);
+		return -ENOMEM;
+	}
+
+	kfree(image->cmdline_buf);
+	image->cmdline_buf_len = cmd_buf_len;
+	image->cmdline_buf = cmd_buf;
+	return 0;
+}
+#endif
+
 void *kexec_file_add_components(struct kimage *image,
 				int (*add_kernel)(struct kimage *image,
 						  struct s390_load_data *data))
@@ -273,15 +333,18 @@ void *kexec_file_add_components(struct kimage *image,
 	if (image->cmdline_buf_len >= max_command_line_size)
 		goto out;
 
-	memcpy(data.parm->command_line, image->cmdline_buf,
-	       image->cmdline_buf_len);
-
 #ifdef CONFIG_CRASH_DUMP
 	if (image->type == KEXEC_TYPE_CRASH) {
 		data.parm->oldmem_base = crashk_res.start;
 		data.parm->oldmem_size = crashk_res.end - crashk_res.start + 1;
 	}
+
+	if (setup_crash_dmcrypt(image, &data, max_command_line_size))
+		goto out;
 #endif
+
+	memcpy(data.parm->command_line, image->cmdline_buf,
+	       image->cmdline_buf_len);
 
 	if (image->initrd_buf) {
 		ret = kexec_file_add_initrd(image, &data);

--- a/arch/x86/include/asm/set_memory.h
+++ b/arch/x86/include/asm/set_memory.h
@@ -4,7 +4,6 @@
 
 #include <asm/page.h>
 #include <asm-generic/set_memory.h>
-#include <asm/pgtable.h>
 
 #define set_memory_rox set_memory_rox
 int set_memory_rox(unsigned long addr, int numpages);
@@ -38,7 +37,6 @@ int set_memory_rox(unsigned long addr, int numpages);
  * The caller is required to take care of these.
  */
 
-int __set_memory_prot(unsigned long addr, int numpages, pgprot_t prot);
 int _set_memory_uc(unsigned long addr, int numpages);
 int _set_memory_wc(unsigned long addr, int numpages);
 int _set_memory_wt(unsigned long addr, int numpages);

--- a/arch/x86/kernel/machine_kexec_64.c
+++ b/arch/x86/kernel/machine_kexec_64.c
@@ -673,10 +673,7 @@ static void kexec_mark_dm_crypt_keys(bool protect)
 		if (protect)
 			set_memory_np((unsigned long)phys_to_virt(start_paddr), nr_pages);
 		else
-			__set_memory_prot(
-				(unsigned long)phys_to_virt(start_paddr),
-				nr_pages,
-				__pgprot(_PAGE_PRESENT | _PAGE_NX | _PAGE_RW));
+			set_memory_p((unsigned long)phys_to_virt(start_paddr), nr_pages);
 	}
 }
 

--- a/arch/x86/mm/pat/set_memory.c
+++ b/arch/x86/mm/pat/set_memory.c
@@ -2145,19 +2145,6 @@ static inline int cpa_clear_pages_array(struct page **pages, int numpages,
 		CPA_PAGES_ARRAY, pages);
 }
 
-/*
- * __set_memory_prot is an internal helper for callers that have been passed
- * a pgprot_t value from upper layers and a reservation has already been taken.
- * If you want to set the pgprot to a specific page protocol, use the
- * set_memory_xx() functions.
- */
-int __set_memory_prot(unsigned long addr, int numpages, pgprot_t prot)
-{
-	return change_page_attr_set_clr(&addr, numpages, prot,
-					__pgprot(~pgprot_val(prot)), 0, 0,
-					NULL);
-}
-
 int _set_memory_uc(unsigned long addr, int numpages)
 {
 	/*

--- a/drivers/of/fdt.c
+++ b/drivers/of/fdt.c
@@ -866,6 +866,25 @@ static void __init early_init_dt_check_for_elfcorehdr(unsigned long node)
 		 elfcorehdr_addr, elfcorehdr_size);
 }
 
+static void __init early_init_dt_check_for_dmcryptkeys(unsigned long node)
+{
+	const __be32 *prop;
+	int len;
+
+	if (!IS_ENABLED(CONFIG_CRASH_DM_CRYPT))
+		return;
+
+	pr_debug("Looking for dmcryptkeys property... ");
+
+	prop = of_get_flat_dt_prop(node, "linux,dmcryptkeys", &len);
+	if (!prop || (len < (dt_root_addr_cells + dt_root_size_cells)))
+		return;
+
+	dm_crypt_keys_addr = dt_mem_next_cell(dt_root_addr_cells, &prop);
+
+	pr_debug("dm_crypt_keys_addr=0x%llx\n", dm_crypt_keys_addr);
+}
+
 static unsigned long chosen_node_offset = -FDT_ERR_NOTFOUND;
 
 /*
@@ -1097,6 +1116,7 @@ int __init early_init_dt_scan_chosen(char *cmdline)
 
 	early_init_dt_check_for_initrd(node);
 	early_init_dt_check_for_elfcorehdr(node);
+	early_init_dt_check_for_dmcryptkeys(node);
 
 	rng_seed = of_get_flat_dt_prop(node, "rng-seed", &l);
 	if (rng_seed && l > 0) {

--- a/drivers/of/kexec.c
+++ b/drivers/of/kexec.c
@@ -432,6 +432,25 @@ void *of_kexec_alloc_and_setup_fdt(const struct kimage *image,
 		if (ret)
 			goto out;
 
+		if (image->dm_crypt_keys_addr != 0) {
+			ret = fdt_appendprop_addrrange(fdt, 0, chosen_node,
+						       "linux,dmcryptkeys",
+						       image->dm_crypt_keys_addr,
+						       image->dm_crypt_keys_sz);
+
+			if (ret)
+				goto out;
+
+			/*
+			 * Avoid dmcryptkeys from being stomped on in kdump kernel by
+			 * setting up memory reserve map.
+			 */
+			ret = fdt_add_mem_rsv(fdt, image->dm_crypt_keys_addr,
+					      image->dm_crypt_keys_sz);
+			if (ret)
+				goto out;
+		}
+
 #ifdef CONFIG_CRASH_DUMP
 		/* add linux,usable-memory-range */
 		ret = fdt_appendprop_addrrange(fdt, 0, chosen_node,

--- a/kernel/crash_dump_dm_crypt.c
+++ b/kernel/crash_dump_dm_crypt.c
@@ -5,6 +5,7 @@
 #include <linux/crash_dump.h>
 #include <linux/cc_platform.h>
 #include <linux/configfs.h>
+#include <linux/memblock.h>
 #include <linux/module.h>
 
 #define KEY_NUM_MAX 128	/* maximum dm crypt keys */
@@ -47,6 +48,26 @@ static int __init setup_dmcryptkeys(char *arg)
 }
 
 early_param("dmcryptkeys", setup_dmcryptkeys);
+
+static int __init setup_dmcryptkeys_size(char *arg)
+{
+	size_t keys_size;
+	int ret;
+
+	if (dm_crypt_keys_addr == 0) {
+		pr_warn("dmcryptkeys=0\n");
+		return -EINVAL;
+	}
+
+	if (!arg)
+		return -EINVAL;
+
+	ret = kstrtoul(arg, 0, &keys_size);
+	memblock_reserve((phys_addr_t)dm_crypt_keys_addr, keys_size);
+	return 0;
+}
+
+early_param("dmcryptkeys_size", setup_dmcryptkeys_size);
 
 /*
  * Architectures may override this function to read dm crypt keys
@@ -415,22 +436,27 @@ int crash_load_dm_crypt_keys(struct kimage *image)
 			return r;
 	}
 
-	kbuf.buffer = keys_header;
-	kbuf.bufsz = get_keys_header_size(key_count);
+	if (!IS_ENABLED(CONFIG_S390)) {
+		kbuf.buffer = keys_header;
+		kbuf.bufsz = get_keys_header_size(key_count);
 
-	kbuf.memsz = kbuf.bufsz;
-	kbuf.buf_align = ELF_CORE_HEADER_ALIGN;
-	kbuf.mem = KEXEC_BUF_MEM_UNKNOWN;
-	r = kexec_add_buffer(&kbuf);
-	if (r) {
-		kvfree((void *)kbuf.buffer);
-		return r;
+		kbuf.memsz = kbuf.bufsz;
+		kbuf.buf_align = ELF_CORE_HEADER_ALIGN;
+		kbuf.mem = KEXEC_BUF_MEM_UNKNOWN;
+		r = kexec_add_buffer(&kbuf);
+		if (r) {
+			kvfree((void *)kbuf.buffer);
+			return r;
+		}
+		image->dm_crypt_keys_addr = kbuf.mem;
+		image->dm_crypt_keys_sz = kbuf.bufsz;
+		kexec_dprintk(
+			"Loaded dm crypt keys to kexec_buffer bufsz=0x%lx memsz=0x%lx\n",
+			kbuf.bufsz, kbuf.memsz);
+	} else {
+		image->dm_crypt_keys_addr = (unsigned long)keys_header;
+		image->dm_crypt_keys_sz = get_keys_header_size(key_count);
 	}
-	image->dm_crypt_keys_addr = kbuf.mem;
-	image->dm_crypt_keys_sz = kbuf.bufsz;
-	kexec_dprintk(
-		"Loaded dm crypt keys to kexec_buffer bufsz=0x%lx memsz=0x%lx\n",
-		kbuf.bufsz, kbuf.memsz);
 
 	return r;
 }


### PR DESCRIPTION
LUKS is the standard for Linux disk encryption, widely adopted by users,
and in some cases, such as Confidential VMs, it is a requirement. With 
kdump enabled, when the first kernel crashes, the system can boot into
the kdump/crash kernel to dump the memory image (i.e., /proc/vmcore) 
to a specified target. However, there are two challenges when dumping
vmcore to a LUKS-encrypted device:

 - Kdump kernel may not be able to decrypt the LUKS partition. For some
   machines, a system administrator may not have a chance to enter the
   password to decrypt the device in kdump initramfs after the 1st kernel
   crashes; For cloud confidential VMs, depending on the policy the
   kdump kernel may not be able to unseal the keys with TPM and the
   console virtual keyboard is untrusted.

 - LUKS2 by default use the memory-hard Argon2 key derivation function
   which is quite memory-consuming compared to the limited memory reserved
   for kdump. Take Fedora example, by default, only 256M is reserved for
   systems having memory between 4G-64G. With LUKS enabled, ~1300M needs
   to be reserved for kdump. Note if the memory reserved for kdump can't
   be used by 1st kernel i.e. an user sees ~1300M memory missing in the
   1st kernel.

Besides users (at least for Fedora) usually expect kdump to work out of
the box i.e. no manual password input or custom crashkernel value is
needed. And it doesn't make sense to derivate the keys again in kdump
kernel which seems to be redundant work.

CONFIG_CRASH_DM_CRYPT addresses the above issues by making the LUKS volume keys
persistent for kdump kernel. This patch set extends the support to  aarch64, ppc64le and s390x.